### PR TITLE
webaudio not working on FF

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -21,10 +21,10 @@
   Dancer.isSupported = function () {
     if ( !window.Float32Array || !window.Uint32Array ) {
       return null;
-    } else if ( !isUnsupportedSafari() && ( window.AudioContext || window.webkitAudioContext )) {
-      return 'webaudio';
     } else if ( audioEl && audioEl.mozSetup ) {
       return 'audiodata';
+    } else if ( !isUnsupportedSafari() && ( window.AudioContext || window.webkitAudioContext )) {
+      return 'webaudio';
     } else if ( FlashDetect.versionAtLeast( 9 ) ) {
       return 'flash';
     } else {


### PR DESCRIPTION
It seems like recent AudioContext support from Firefox broke dancer.js behavior, making `Dancer._getAdapter` returns the webkit adapter on FF instead of the moz adapter. The problem is caused from an assumption in `Dancer.isSupported`, where the existence of `window.AudioContext` is considered as a non-moz browser.

I wraped up this issue by checking first for moz browsers instead of webkit, this way everything went back to normal.
