### PR TITLE
Update to make dancer.js work again in Firefox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dancer.js
 ======
 
-dancer.js is a high-level audio API, usable with both Mozilla's Audio Data API and Webkit's Web Audio API with flash fallback, designed to make sweet visualizations.
+dancer.js is a high-level audio API, usable with both Mozilla's Audio Data API and Web Audio API with flash fallback, designed to make sweet visualizations.
 
 http://jsantell.github.com/dancer.js
 
@@ -13,7 +13,7 @@ Features
 * Use Dancer to get audio data from any preexisting audio source
 * Leverage kick detection into your visualizations
 * Simple API to time callbacks and events to any section of a song
-* Supports Web Audio (webkit), Audio Data (mozilla) and flash fallback (v9+)
+* Supports Web Audio (webkit/mozilla), Audio Data (mozilla) and flash fallback (v9+)
 * Extensible framework supporting plugins and custom behaviours
 
 Dancer Instance Methods
@@ -184,6 +184,10 @@ This project uses [grunt](https://github.com/cowboy/grunt) to build and [jasmine
 
 Change Logs
 ----
+**v0.3.3 (1/28/2014)**
+* Update to work with new Web Audio function names. Dancer now uses Web Audio in
+  Firefox 25+.
+
 **v0.3.2 (9/29/2012)**
 * Change build process to using grunt.js
 

--- a/dancer.js
+++ b/dancer.js
@@ -258,7 +258,7 @@
   Dancer._getAdapter = function ( instance ) {
     switch ( Dancer.isSupported() ) {
       case 'webaudio':
-        return new Dancer.adapters.webkit( instance );
+        return new Dancer.adapters.webaudio( instance );
       case 'audiodata':
         return new Dancer.adapters.moz( instance );
       case 'flash':

--- a/examples/audio_element/index.html
+++ b/examples/audio_element/index.html
@@ -28,7 +28,7 @@
 		<script src="../../src/dancer.js"></script>
 		<script src="../../src/support.js"></script>
 		<script src="../../src/kick.js"></script>
-		<script src="../../src/adapterWebkit.js"></script>
+		<script src="../../src/adapterWebAudio.js"></script>
 		<script src="../../src/adapterMoz.js"></script>
 		<script src="../../src/adapterFlash.js"></script>
 		<script src="../../lib/fft.js"></script>

--- a/examples/fft/index.html
+++ b/examples/fft/index.html
@@ -24,7 +24,7 @@
 		<script src="../../src/dancer.js"></script>
 		<script src="../../src/support.js"></script>
 		<script src="../../src/kick.js"></script>
-		<script src="../../src/adapterWebkit.js"></script>
+		<script src="../../src/adapterWebAudio.js"></script>
 		<script src="../../src/adapterMoz.js"></script>
 		<script src="../../src/adapterFlash.js"></script>
 		<script src="../../lib/fft.js"></script>

--- a/examples/single_song_demo/index.html
+++ b/examples/single_song_demo/index.html
@@ -29,7 +29,7 @@
 		<script src="../../src/dancer.js"></script>
 		<script src="../../src/support.js"></script>
 		<script src="../../src/kick.js"></script>
-		<script src="../../src/adapterWebkit.js"></script>
+		<script src="../../src/adapterWebAudio.js"></script>
 		<script src="../../src/adapterMoz.js"></script>
 		<script src="../../src/adapterFlash.js"></script>
 		<script src="../../lib/fft.js"></script>

--- a/examples/waveform/index.html
+++ b/examples/waveform/index.html
@@ -24,7 +24,7 @@
 		<script src="../../src/dancer.js"></script>
 		<script src="../../src/support.js"></script>
 		<script src="../../src/kick.js"></script>
-		<script src="../../src/adapterWebkit.js"></script>
+		<script src="../../src/adapterWebAudio.js"></script>
 		<script src="../../src/adapterMoz.js"></script>
 		<script src="../../src/adapterFlash.js"></script>
 		<script src="../../lib/fft.js"></script>

--- a/grunt.js
+++ b/grunt.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
           'src/dancer.js',
           'src/support.js',
           'src/kick.js',
-          'src/adapterWebkit.js',
+          'src/adapterWebAudio.js',
           'src/adapterMoz.js',
           'src/adapterFlash.js',
           'lib/fft.js',
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
         'src/dancer.js',
         'src/support.js',
         'src/kick.js',
-        'src/adapterWebkit.js',
+        'src/adapterWebAudio.js',
         'src/adapterMoz.js',
         'src/adapterFlash.js'
       ]

--- a/spec/dancer.js
+++ b/spec/dancer.js
@@ -129,7 +129,7 @@ describe('Dancer', function () {
           currentTime = dancer.getTime();
           waits( 1000 );
           runs(function () {
-            expect(dancer.getTime()).toBeWithin(currentTime + 1.0, 0.05);
+            expect(dancer.getTime()).toBeWithin(currentTime + 1.0, 0.1);
             dancer.pause();
           });
         });

--- a/spec/index.html
+++ b/spec/index.html
@@ -14,7 +14,7 @@
   <script src="../src/dancer.js"></script>
   <script src="../src/support.js"></script>
   <script src="../src/kick.js"></script>
-  <script src="../src/adapterWebkit.js"></script>
+  <script src="../src/adapterWebAudio.js"></script>
   <script src="../src/adapterMoz.js"></script>
   <script src="../src/adapterFlash.js"></script>
   <script src="../lib/fft.js"></script>

--- a/src/adapterWebAudio.js
+++ b/src/adapterWebAudio.js
@@ -20,11 +20,19 @@
       this.isLoaded = false;
       this.progress = 0;
 
-      this.proc = this.context.createJavaScriptNode( SAMPLE_SIZE / 2, 1, 1 );
+      if (!this.context.createScriptProcessor) {
+        this.context.createScriptProcessor = this.context.createJavascriptNode;
+      }
+      this.proc = this.context.createScriptProcessor( SAMPLE_SIZE / 2, 1, 1 );
+
       this.proc.onaudioprocess = function ( e ) {
         _this.update.call( _this, e );
       };
-      this.gain = this.context.createGainNode();
+      if (!this.context.createGain) {
+        this.context.createGain = this.context.createGainNode;
+      }
+
+      this.gain = this.context.createGain();
 
       this.fft = new FFT( SAMPLE_SIZE / 2, SAMPLE_RATE );
       this.signal = new Float32Array( SAMPLE_SIZE / 2 );
@@ -118,6 +126,6 @@
     this.dancer.trigger( 'loaded' );
   }
 
-  Dancer.adapters.webkit = adapter;
+  Dancer.adapters.webaudio = adapter;
 
 })();

--- a/src/support.js
+++ b/src/support.js
@@ -61,7 +61,7 @@
   Dancer._getAdapter = function ( instance ) {
     switch ( Dancer.isSupported() ) {
       case 'webaudio':
-        return new Dancer.adapters.webkit( instance );
+        return new Dancer.adapters.webaudio( instance );
       case 'audiodata':
         return new Dancer.adapters.moz( instance );
       case 'flash':


### PR DESCRIPTION
Basically:
- rename the webkit backend to webaudio (as web audio is supported in Gecko, now), update callsites and paths ;
- Fuzz a clock test a bit more to make it green ;
- Alter the readme to reflect the changes ; 
- Update the change log ;
- Make sure use the new Web Audio names (the other are deprecated), with proper fallback ;
