### PR TITLE
Call to Dancer.adapters.webaudio returns undefined

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -61,7 +61,7 @@
   Dancer._getAdapter = function ( instance ) {
     switch ( Dancer.isSupported() ) {
       case 'webaudio':
-        return new Dancer.adapters.webaudio( instance );
+        return new Dancer.adapters.webkit( instance );
       case 'audiodata':
         return new Dancer.adapters.moz( instance );
       case 'flash':


### PR DESCRIPTION
It looks like you are calling `Dancer.adapters.webaudio` (which is undefined) rather than `Dancer.adapters.webkit`.
